### PR TITLE
all: do not use *.cc file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 
 ## Recognized file-types
 
-Default recognised file extensions are `.yag`, `.yagpdb`, `.yagcc`, `.cc`, `.cc.go` and `.yagpdbcc`. 
+Default recognised file extensions are `.yag`, `.yagpdb`, `.yagcc`, , `.cc.go` and `.yagpdbcc`. 
 You can also change the language of the file to `"YAGPDB-CC"`.
 
 > ℹ️ **INFO**<br />

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
                     ".yagpdb",
                     ".yagcc",
                     ".yagpdbcc",
-                    ".cc.go",
-                    ".cc"
+                    ".cc.go"
                 ],
                 "configuration": "./language-configuration.json",
                 "icon": {


### PR DESCRIPTION
Do not recognise the cc file extension as YAGPDB-CC, as this file
extension is already in use by C++.

From `man 1 gcc` "Compiling C++ Programs":

> C++ source files conventionally use one of the suffixes .C, .cc, .cpp,
> .CPP, .c++, .cp, or .cxx; C++ header files often  use .hh, .hpp, .H, or
> (for shared template code) .tcc; and preprocessed C++ files use the
> suffix .ii.  GCC recognizes files with these  names  and  compiles  them
> as  C++  programs  even if you call the compiler the same way as for
> compiling C programs (usually with the name gcc).

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
